### PR TITLE
Log to stderr by default

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -165,7 +165,7 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 		if packet.TypeInstance != "" {
 			typeName += "-" + packet.TypeInstance
 		} else if t != nil {
-			typeName += "-" + t[i]
+			typeName += "-" + t[i][0]
 		}
 
 		name := hostName + "." + pluginName + "." + typeName

--- a/typesdb.go
+++ b/typesdb.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-type Types map[string][]string
+type Types map[string][][]string
 
 // Parses types.db file.
 // The result map looks like this:
@@ -33,7 +33,7 @@ func ParseTypesDB(path string) (Types, error) {
 			continue
 		}
 
-		types := []string{}
+		types := [][]string{}
 		for _, v := range fields[1:] {
 			if len(v) == 0 {
 				continue
@@ -47,7 +47,7 @@ func ParseTypesDB(path string) (Types, error) {
 				continue
 			}
 
-			types = append(types, vFields...)
+			types = append(types, vFields)
 		}
 		result[typeName] = types
 	}


### PR DESCRIPTION
I suggest changing logging behavior to log to stderr by default — which I think is more idiomatic of a Go application —, unless a log path is provided. Let me know what you think :)
