### PR TITLE
Fix collectd types.db parsing

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -161,7 +161,7 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 		if packet.TypeInstance != "" {
 			typeName += "-" + packet.TypeInstance
 		} else if t != nil {
-			typeName += "-" + t[i]
+			typeName += "-" + t[i][0]
 		}
 
 		name := hostName + "." + pluginName + "." + typeName

--- a/typesdb.go
+++ b/typesdb.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-type Types map[string][]string
+type Types map[string][][]string
 
 // Parses types.db file.
 // The result map looks like this:
@@ -33,7 +33,7 @@ func ParseTypesDB(path string) (Types, error) {
 			continue
 		}
 
-		types := []string{}
+		types := [][]string{}
 		for _, v := range fields[1:] {
 			if len(v) == 0 {
 				continue
@@ -47,7 +47,7 @@ func ParseTypesDB(path string) (Types, error) {
 				continue
 			}
 
-			types = append(types, vFields...)
+			types = append(types, vFields)
 		}
 		result[typeName] = types
 	}


### PR DESCRIPTION
Fixes a bug in collectd's types.db file parsing causing the types
featuring more than one DS to be incorrectly looked up when processing
collectd packets.
