### PR TITLE
updated proxy.go to include hostname as a column rather than a series pr...

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -39,6 +39,7 @@ var (
 // point cache to perform data normalization for COUNTER and DERIVE types
 type CacheEntry struct {
 	Timestamp int64
+	Hostname  string
 	Value     float64
 }
 
@@ -172,7 +173,8 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 			typeName += "-" + t[i][0]
 		}
 
-		name := hostName + "." + pluginName + "." + typeName
+		//name := hostName + "." + pluginName + "." + typeName
+		name := "collectd." + pluginName + "." + typeName
 
 		// influxdb stuffs
 		timestamp := packet.Time().UnixNano() / 1000000
@@ -195,6 +197,7 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 			}
 			entry := CacheEntry{
 				Timestamp: timestamp,
+				Hostname: hostName,
 				Value:     value,
 			}
 			beforeCache[name] = entry
@@ -203,9 +206,9 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 		if readyToSend {
 			series := &influxdb.Series{
 				Name:    name,
-				Columns: []string{"time", "value"},
+				Columns: []string{"time", "hostname", "value"},
 				Points: [][]interface{}{
-					[]interface{}{timestamp, normalizedValue},
+					[]interface{}{timestamp, hostName, normalizedValue},
 				},
 			}
 			if *verbose {


### PR DESCRIPTION
...efix

@hoonmin - Thanks for writing this proxy! It's much more reliable than some others I've tried.

Would you be interested in this change to include the hostname as a column to each time series, rather than as a prefix to each series?

In my testing, I've found that InfluxDB is more performant when there are fewer time series to manage. Grouping similar metrics into a single series with a distinguishing field (such as hostname) yields better query performance, usually.

So far this change is working locally and handling metrics just fine, but let me know if I did anything you don't like. :-)