### PR TITLE
Added option -hostname-as-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ bin/proxy --typesdb="types.db" --database="collectd" --username="collectd" --p
 $ bin/proxy --help
 Usage of bin/proxy:
   -database="": database for influxdb
+  -hostname-as-column=false: true if you want the hostname as column, not in series name
   -influxdb="localhost:8086": host:port for influxdb
   -logfile="proxy.log": path to log file
   -normalize=true: true if you need to normalize data for COUNTER types (over time)
@@ -67,3 +68,4 @@ This project is maintained with following contributors' supports.
 - falzm (http://github.com/falzm)
 - vbatoufflet (http://github.com/vbatoufflet)
 - cstorey (http://github.com/cstorey)
+- jeroenbo (http://github.com/jeroenbo)


### PR DESCRIPTION
Example usage: select sum(value) from "apache.apache_requests-count" group by time(1m)
Purpose: Easy query and aggregate multiple servers

Committer: Jeroen Boonstra <jeroen@provider.nl>