### PR TITLE
system and instances to add hostname / pluginname as columns in influxdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOPATH:=$(GOPATH):`pwd`
 BIN=bin
-EXE=proxy
+EXE=influxdb-collectd-proxy
 
 GOCOLLECTD=github.com/paulhammond/gocollectd
 INFLUXDBGO=github.com/influxdb/influxdb/client

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ bin/influxdb-collectd-proxy --typesdb="/usr/share/collectd/types.db" --databas
 $ bin/influxdb-collectd-proxy --help
 Usage of bin/influxdb-collectd-proxy:
   -database="": database for influxdb
+  -pluginname-as-column=false: true if you want the pluginname as column
   -influxdb="localhost:8086": host:port for influxdb
   -logfile="proxy.log": path to log file
   -normalize=true: true if you need to normalize data for COUNTER types (over time)

--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ This project is maintained with following contributors' supports.
 - cstorey (http://github.com/cstorey)
 - yanfali (http://github.com/yanfali)
 - linyanzhong (http://github.com/linyanzhong)
+- rplessl (http://github.com/rplessl)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, add following lines to collectd.conf then restart the collectd daemon.
 LoadPlugin network
 
 <Plugin network>
-  # proxy address
+  # influxdb collectd proxy address
   Server "127.0.0.1" "8096"
 </Plugin>
 ```
@@ -27,14 +27,14 @@ LoadPlugin network
 And start the proxy.
 
 ```
-$ bin/proxy --typesdb="types.db" --database="collectd" --username="collectd" --password="collectd"
+$ bin/influxdb-collectd-proxy --typesdb="/usr/share/collectd/types.db" --database="collectd" --username="collectd" --password="collectd"
 ```
 
 ## Options
 
 ```
-$ bin/proxy --help
-Usage of bin/proxy:
+$ bin/influxdb-collectd-proxy --help
+Usage of bin/influxdb-collectd-proxy:
   -database="": database for influxdb
   -influxdb="localhost:8086": host:port for influxdb
   -logfile="proxy.log": path to log file

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ bin/influxdb-collectd-proxy --typesdb="/usr/share/collectd/types.db" --databas
 $ bin/influxdb-collectd-proxy --help
 Usage of bin/influxdb-collectd-proxy:
   -database="": database for influxdb
+  -hostname-as-column=false: true if you want the hostname as column, not in series name
   -pluginname-as-column=false: true if you want the pluginname as column
   -influxdb="localhost:8086": host:port for influxdb
   -logfile="proxy.log": path to log file
@@ -86,6 +87,7 @@ This project is maintained with following contributors' supports.
 - falzm (http://github.com/falzm)
 - vbatoufflet (http://github.com/vbatoufflet)
 - cstorey (http://github.com/cstorey)
+- jeroenbo (http://github.com/jeroenbo)
 - yanfali (http://github.com/yanfali)
 - linyanzhong (http://github.com/linyanzhong)
 - rplessl (http://github.com/rplessl)

--- a/influxdb-collectd-proxy.go
+++ b/influxdb-collectd-proxy.go
@@ -13,6 +13,7 @@ import (
 	collectd "github.com/paulhammond/gocollectd"
 )
 
+const appName = "influxdb-collectd-proxy"
 const influxWriteInterval = time.Second
 const influxWriteLimit = 50
 
@@ -52,6 +53,9 @@ func handleSignals(c chan os.Signal) {
 }
 
 func init() {
+	// log options
+	log.SetPrefix("[" + appName + "] ")
+
 	// proxy options
 	proxyHost = flag.String("proxyhost", "0.0.0.0", "host for proxy")
 	proxyPort = flag.String("proxyport", "8096", "port for proxy")


### PR DESCRIPTION
This patch adds:
- an enhanceable system for adding additional columns in influxdb
- added hostname column as one instance [1]
- added pluginname column as another instance of this system

[1]: enhancement of pull request https://github.com/hoonmin/influxdb-collectd-proxy/pull/16 from @JeroenBo (JeroenBo@0a0140e2a43cdfe7b8084ed9f171bbb98fe7524a)