### PR TITLE
Use Godep to track which version dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,15 @@
+{
+	"ImportPath": "github.com/hoonmin/influxdb-collectd-proxy",
+	"GoVersion": "go1.4.1",
+	"Deps": [
+		{
+			"ImportPath": "github.com/influxdb/influxdb/client",
+			"Comment": "v0.8.6",
+			"Rev": "a0fd0cd03efd284fed64bb598f9c1e5fa1d984e5"
+		},
+		{
+			"ImportPath": "github.com/paulhammond/gocollectd",
+			"Rev": "8f48e457ea036c6405db352d5be1ecf92d4b43bf"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.


### PR DESCRIPTION
influxdb client has changed API, only versions before 0.8.7
appear to work without code changes.

Install godep:

```
  go get tools/godep
```

Use `godep restore` to pull the correct dependencies.
Use `godep save` to update dependencies.