### PR TITLE
Added support for influx series name prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ BUILDDIR := $(PWD)/build
 
 all: clean install build
 
-build:
+install:
 	GOPATH=$(BUILDDIR) go get github.com/tools/godep
 	GOPATH=$(BUILDDIR) $(BUILDDIR)/bin/godep restore
+
+build:
 	GOPATH=$(BUILDDIR) go build -o $(BUILDDIR)/bin/influxdb-collectd-proxy
 
 clean: 

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,12 @@
-GOPATH:=$(GOPATH):`pwd`
-BIN=bin
-EXE=influxdb-collectd-proxy
+PWD := $(shell pwd)
+BUILDDIR := $(PWD)/build
 
-GOCOLLECTD=github.com/paulhammond/gocollectd
-INFLUXDBGO=github.com/influxdb/influxdb/client
-
-all: get build
-
-get:
-	GOPATH=$(GOPATH) go get $(GOCOLLECTD)
-	GOPATH=$(GOPATH) go get $(INFLUXDBGO)
+all: clean install build
 
 build:
-	GOPATH=$(GOPATH) go build -o $(BIN)/$(EXE)
+	GOPATH=$(BUILDDIR) go get github.com/tools/godep
+	GOPATH=$(BUILDDIR) $(BUILDDIR)/bin/godep restore
+	GOPATH=$(BUILDDIR) go build -o $(BUILDDIR)/bin/influxdb-collectd-proxy
 
 clean: 
-	rm -rf src
-	rm -rf pkg
-	rm -rf bin
+	rm -rf $(BUILDDIR)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 influxdb-collectd-proxy
 =======================
 
+[![Build Status](https://travis-ci.org/yulis/influxdb-collectd-proxy.svg?branch=master)](https://travis-ci.org/yulis/influxdb-collectd-proxy)
+
 A very simple proxy between collectd and influxdb.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ This project is maintained with following contributors' supports.
 - yanfali (http://github.com/yanfali)
 - linyanzhong (http://github.com/linyanzhong)
 - rplessl (http://github.com/rplessl)
+- yulis (http://github.com/yulis)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ bin/influxdb-collectd-proxy --typesdb="/usr/share/collectd/types.db" --databas
 $ bin/influxdb-collectd-proxy --help
 Usage of bin/influxdb-collectd-proxy:
   -database="": database for influxdb
+  -prefix="": prefix for influxdb timeseries name
   -hostname-as-column=false: true if you want the hostname as column, not in series name
   -pluginname-as-column=false: true if you want the pluginname as column
   -influxdb="localhost:8086": host:port for influxdb

--- a/influxdb-collectd-proxy.go
+++ b/influxdb-collectd-proxy.go
@@ -40,6 +40,7 @@ var (
 	// Format
 	hostnameAsColumn   *bool
 	pluginnameAsColumn *bool
+	prefix             *string
 
 	types       Types
 	client      *influxdb.Client
@@ -92,6 +93,7 @@ func init() {
 	// format options
 	hostnameAsColumn = flag.Bool("hostname-as-column", false, "true if you want the hostname as column, not in series name")
 	pluginnameAsColumn = flag.Bool("pluginname-as-column", false, "true if you want the plugin name as column")
+	prefix = flag.String("prefix", "", "influxdb series prefix")
 	flag.Parse()
 
 	beforeCache = make(map[string]CacheEntry)
@@ -253,6 +255,11 @@ func processPacket(packet collectd.Packet) []*influxdb.Series {
 			if *pluginnameAsColumn {
 				columns = append(columns, "plugin")
 				points_values = append(points_values, pluginName)
+			}
+
+			// prepend prefix if not empty
+			if len(*prefix) > 0 {
+				name_value = strings.Join([]string{*prefix,name_value}, ".")
 			}
 
 			series := &influxdb.Series{

--- a/influxdb-collectd-proxy.go
+++ b/influxdb-collectd-proxy.go
@@ -93,7 +93,7 @@ func init() {
 	// format options
 	hostnameAsColumn = flag.Bool("hostname-as-column", false, "true if you want the hostname as column, not in series name")
 	pluginnameAsColumn = flag.Bool("pluginname-as-column", false, "true if you want the plugin name as column")
-	prefix = flag.String("prefix", "", "influxdb series prefix")
+	prefix = flag.String("prefix", "", "prefix for influxdb timeseries name")
 	flag.Parse()
 
 	beforeCache = make(map[string]CacheEntry)


### PR DESCRIPTION
Useful when you have a complex graphite-like naming convention for the metrics. Allows you to be consistent with graphite sources for Graphana
